### PR TITLE
Repository fixtures

### DIFF
--- a/Speedruns.Backend.Tests/Repositories/CommentsRepositoryTests.cs
+++ b/Speedruns.Backend.Tests/Repositories/CommentsRepositoryTests.cs
@@ -1,29 +1,23 @@
 ﻿using Speedruns.Backend.Entities;
-using Speedruns.Backend.Repositories;
-using Speedruns.Backend.Tests.Database;
+using Speedruns.Backend.Tests._Fixtures.Repositories;
 
 namespace Speedruns.Backend.Tests.Repositories
 {
-    public class CommentsRepositoryTests
+    public class CommentsRepositoryTests : IClassFixture<CommentsRepositoryFixture>
     {
-        private DbContextMock<CommentEntity> _dbContextMock;
-        private CommentsRepository _commentsRepository;
+        private readonly CommentsRepositoryFixture _fixture;
 
-        public CommentsRepositoryTests()
+        public CommentsRepositoryTests(CommentsRepositoryFixture fixture)
         {
-            _dbContextMock = new DbContextMock<CommentEntity>(new List<CommentEntity>
-            {
-                new CommentEntity { Id = 1, Date = DateTime.UtcNow, Text = "Comment 1", UserId = 1, RunId = 1 },
-                new CommentEntity { Id = 2, Date = DateTime.UtcNow, Text = "Comment 2", UserId = 1, RunId = 1 },
-            });
-
-            _commentsRepository = new CommentsRepository(_dbContextMock.Context);
+            _fixture = fixture;
         }
 
         [Fact]
         public async Task ShouldReturnCommentsByRunId()
         {
-            var comments = await _commentsRepository.GetComments(1);
+            _fixture.ResetRepository();
+
+            var comments = await _fixture.Repository.GetComments(1);
 
             Assert.NotNull(comments);
             Assert.IsType<List<CommentEntity>>(comments);
@@ -35,7 +29,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnCommentByCommentId()
         {
-            var comment = await _commentsRepository.GetCommentById(1);
+            _fixture.ResetRepository();
+            var comment = await _fixture.Repository.GetCommentById(1);
 
             Assert.NotNull(comment);
             Assert.IsType<CommentEntity>(comment);
@@ -46,7 +41,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnNullCommentByCommentId()
         {
-            var comment = await _commentsRepository.GetCommentById(100);
+            _fixture.ResetRepository();
+            var comment = await _fixture.Repository.GetCommentById(100);
 
             Assert.Null(comment);
         }
@@ -54,11 +50,12 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldAddComment()
         {
+            _fixture.ResetRepository();
             var newComment = new CommentEntity { Id = 3, Date = DateTime.UtcNow, Text = "Comment 3", UserId = 1, RunId = 1 };
 
-            await _commentsRepository.AddComment(newComment);
+            await _fixture.Repository.AddComment(newComment);
 
-            var comment = await _commentsRepository.GetCommentById(3);
+            var comment = await _fixture.Repository.GetCommentById(3);
 
             Assert.NotNull(comment);
             Assert.IsType<CommentEntity>(comment);
@@ -69,11 +66,12 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldUpdateComment()
         {
+            _fixture.ResetRepository();
             var newComment = new CommentEntity { Id = 1, Date = DateTime.UtcNow, Text = "Comment 1 Updated", UserId = 1, RunId = 1 };
 
-            await _commentsRepository.UpdateComment(newComment);
+            await _fixture.Repository.UpdateComment(newComment);
 
-            var comment = await _commentsRepository.GetCommentById(1);
+            var comment = await _fixture.Repository.GetCommentById(1);
 
             Assert.NotNull(comment);
             Assert.IsType<CommentEntity>(comment);
@@ -84,11 +82,12 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldDeleteComment()
         {
-            var commentToDelete = await _commentsRepository.GetCommentById(1);
+            _fixture.ResetRepository();
+            var commentToDelete = await _fixture.Repository.GetCommentById(1);
 
-            await _commentsRepository.DeleteComment(commentToDelete);
+            await _fixture.Repository.DeleteComment(commentToDelete);
 
-            var comment = await _commentsRepository.GetCommentById(1);
+            var comment = await _fixture.Repository.GetCommentById(1);
 
             Assert.Null(comment);
         }

--- a/Speedruns.Backend.Tests/Repositories/ConsoleRepositoryTests.cs
+++ b/Speedruns.Backend.Tests/Repositories/ConsoleRepositoryTests.cs
@@ -1,28 +1,21 @@
 ﻿using Speedruns.Backend.Entities;
-using Speedruns.Backend.Tests.Database;
-using Speedruns.Backend.Repositories;
+using Speedruns.Backend.Tests._Fixtures.Repositories;
 
 namespace Speedruns.Backend.Tests.Repositories
 {
-    public class ConsoleRepositoryTests
+    public class ConsoleRepositoryTests : IClassFixture<ConsolesRepositoryFixture>
     {
-        private DbContextMock<ConsoleEntity> _dbContextMock;
-        private ConsolesRepository _consoleRepository;
+        private readonly ConsolesRepositoryFixture _fixture;
 
-        public ConsoleRepositoryTests()
+        public ConsoleRepositoryTests(ConsolesRepositoryFixture fixture)
         {
-            _dbContextMock = new DbContextMock<ConsoleEntity>(new List<ConsoleEntity>
-            {
-                new ConsoleEntity { Id = 1, Name = "Console 1" },
-                new ConsoleEntity { Id = 2, Name = "Console 2" },
-            });
-            _consoleRepository = new ConsolesRepository(_dbContextMock.Context);
+            _fixture = fixture;
         }
 
         [Fact]
         public async Task ShouldReturnListOfConsoles()
         {
-            var consoles = await _consoleRepository.GetAll();
+            var consoles = await _fixture.Repository.GetAll();
 
             Assert.NotNull(consoles);
             Assert.IsType<List<ConsoleEntity>>(consoles);

--- a/Speedruns.Backend.Tests/Repositories/GamesRepositoryTests.cs
+++ b/Speedruns.Backend.Tests/Repositories/GamesRepositoryTests.cs
@@ -1,29 +1,21 @@
 ﻿using Speedruns.Backend.Entities;
-using Speedruns.Backend.Repositories;
-using Speedruns.Backend.Tests.Database;
+using Speedruns.Backend.Tests._Fixtures.Repositories;
 
 namespace Speedruns.Backend.Tests.Repositories
 {
-    public class GamesRepositoryTests
+    public class GamesRepositoryTests : IClassFixture<GamesRepositoryFixture>
     {
-        private DbContextMock<GameEntity> _dbContextMock;
-        private GamesRepository _gamesRepository;
+       private readonly GamesRepositoryFixture _fixture;
 
-        public GamesRepositoryTests()
+        public GamesRepositoryTests(GamesRepositoryFixture fixture)
         {
-            _dbContextMock = new DbContextMock<GameEntity>(new List<GameEntity>
-            {
-                new GameEntity { Id = 1, Name = "Super Mario 64", ReleaseYear = 1996, Players = 100, RunsPublished = 1000 },
-                new GameEntity { Id = 2, Name = "Kingdom Hearts 2 Final Mix", ReleaseYear = 2007, Players = 50, RunsPublished = 1000 },
-            });
-
-            _gamesRepository = new GamesRepository(_dbContextMock.Context);
+            _fixture = fixture;
         }
 
         [Fact]
         public async Task ShouldReturnListOfGames()
         {
-            var games = await _gamesRepository.GetAll();
+            var games = await _fixture.Repository.GetAll();
 
             Assert.NotNull(games);
             Assert.IsType<List<GameEntity>>(games);
@@ -33,7 +25,7 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnGameById()
         {
-            var game = await _gamesRepository.GetById(1);
+            var game = await _fixture.Repository.GetById(1);
 
             Assert.NotNull(game);
             Assert.IsType<GameEntity>(game);
@@ -44,7 +36,7 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnGameByName()
         {
-            var game = await _gamesRepository.GetByName("Kingdom Hearts 2 Final Mix");
+            var game = await _fixture.Repository.GetByName("Kingdom Hearts 2 Final Mix");
 
             Assert.NotNull(game);
             Assert.IsType<GameEntity>(game);

--- a/Speedruns.Backend.Tests/Repositories/RunRepositoryTests.cs
+++ b/Speedruns.Backend.Tests/Repositories/RunRepositoryTests.cs
@@ -1,44 +1,22 @@
-﻿using NSubstitute;
-using Speedruns.Backend.Entities;
-using Speedruns.Backend.Interfaces;
-using Speedruns.Backend.Repositories;
-using Speedruns.Backend.Tests.Database;
+﻿using Speedruns.Backend.Entities;
+using Speedruns.Backend.Tests._Fixtures.Repositories;
 
 namespace Speedruns.Backend.Tests.Repositories
 {
-    public class RunRepositoryTests
+    public class RunRepositoryTests : IClassFixture<RunRepositoryFixture>
     {
-        private DbContextMock<RunEntity> _dbContextMock;
-        private RunRepository _runRepository;
-        private IGamesRepository _gamesRepository;
+        private readonly RunRepositoryFixture _fixture;
 
-        public RunRepositoryTests()
+        public RunRepositoryTests(RunRepositoryFixture fixture)
         {
-            _dbContextMock = new DbContextMock<RunEntity>(new List<RunEntity>
-            {
-                new RunEntity { Id = 1, UserId = 1, GameId = 1, Time = 123, Console = new ConsoleEntity { Name = "PlayStation 1" } },
-                new RunEntity { Id = 2, UserId = 1, GameId = 2, Time = 123 },
-            });
-
-            _gamesRepository = Substitute.For<IGamesRepository>();
-            _gamesRepository
-                .GetById(1)
-                .Returns(new GameEntity
-                {
-                    Id = 1,
-                    Name = "Super Mario 64",
-                    ReleaseYear = 1996,
-                    Players = 100,
-                    RunsPublished = 1000
-                });
-
-            _runRepository = new RunRepository(_dbContextMock.Context, _gamesRepository);
+            _fixture = fixture;
         }
 
         [Fact]
         public async Task ShouldReturnListOfRuns()
         {
-            var runs = await _runRepository.GetAll();
+            _fixture.ResetRepository();
+            var runs = await _fixture.RunRepository.GetAll();
 
             Assert.NotNull(runs);
             Assert.IsType<List<RunEntity>>(runs);
@@ -48,7 +26,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnRunById()
         {
-            var run = await _runRepository.GetById(1);
+            _fixture.ResetRepository();
+            var run = await _fixture.RunRepository.GetById(1);
 
             Assert.NotNull(run);
             Assert.IsType<RunEntity>(run);
@@ -58,7 +37,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnNullRunById()
         {
-            var run = await _runRepository.GetById(100);
+            _fixture.ResetRepository();
+            var run = await _fixture.RunRepository.GetById(100);
 
             Assert.Null(run);
         }
@@ -66,7 +46,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnRunsByUser()
         {
-            var runs = await _runRepository.GetUserRuns(1);
+            _fixture.ResetRepository();
+            var runs = await _fixture.RunRepository.GetUserRuns(1);
 
             Assert.NotNull(runs);
             Assert.IsType<List<RunEntity>>(runs);
@@ -76,7 +57,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnEmptyListRunsByUser()
         {
-            var runs = await _runRepository.GetUserRuns(100);
+            _fixture.ResetRepository();
+            var runs = await _fixture.RunRepository.GetUserRuns(100);
 
             Assert.Empty(runs);
         }
@@ -84,13 +66,14 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldCreateRun()
         {
+            _fixture.ResetRepository();
             var newRun = new RunEntity { Id = 3, GameId = 1, UserId = 1 };
 
-            var game = await _gamesRepository.GetById(newRun.GameId);
+            var game = await _fixture.GameRepository.GetById(newRun.GameId);
 
-            await _runRepository.CreateRun(newRun, game);
+            await _fixture.RunRepository.CreateRun(newRun, game);
 
-            var run = await _runRepository.GetById(newRun.Id);
+            var run = await _fixture.RunRepository.GetById(newRun.Id);
 
             Assert.NotNull(run);
             Assert.IsType<RunEntity>(run);
@@ -100,15 +83,16 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldUpdateRun()
         {
+            _fixture.ResetRepository();
             var newRun = new RunEntity { Id = 1, UserId = 1, GameId = 1, Console = new ConsoleEntity { Name = "PlayStation 2" }, Date = DateTime.UtcNow };
 
-            var runToUpdate = await _runRepository.GetById(newRun.Id);
+            var runToUpdate = await _fixture.RunRepository.GetById(newRun.Id);
 
             var oldDate = runToUpdate.Date;
 
-            await _runRepository.UpdateRun(runToUpdate, newRun);
+            await _fixture.RunRepository.UpdateRun(runToUpdate, newRun);
 
-            var run = await _runRepository.GetById(1);
+            var run = await _fixture.RunRepository.GetById(1);
 
             Assert.NotNull(run);
             Assert.IsType<RunEntity>(run);
@@ -120,11 +104,12 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldDeleteRun()
         {
-            var runToDelete = await _runRepository.GetById(1);
+            _fixture.ResetRepository();
+            var runToDelete = await _fixture.RunRepository.GetById(1);
 
-            await _runRepository.DeleteRun(runToDelete);
+            await _fixture.RunRepository.DeleteRun(runToDelete);
 
-            var run = await _runRepository.GetById(1);
+            var run = await _fixture.RunRepository.GetById(1);
 
             Assert.Null(run);
         }

--- a/Speedruns.Backend.Tests/Repositories/SeriesRepositoryTests.cs
+++ b/Speedruns.Backend.Tests/Repositories/SeriesRepositoryTests.cs
@@ -1,29 +1,21 @@
 ﻿using Speedruns.Backend.Entities;
-using Speedruns.Backend.Repositories;
-using Speedruns.Backend.Tests.Database;
+using Speedruns.Backend.Tests._Fixtures.Repositories;
 
 namespace Speedruns.Backend.Tests.Repositories
 {
-    public class SeriesRepositoryTests
+    public class SeriesRepositoryTests : IClassFixture<SeriesRepositoryFixture>
     {
-        private DbContextMock<SeriesEntity> _dbContextMock;
-        private SeriesRepository _seriesRepository;
+        private readonly SeriesRepositoryFixture _fixture;
 
-        public SeriesRepositoryTests()
+        public SeriesRepositoryTests(SeriesRepositoryFixture fixture)
         {
-            _dbContextMock = new DbContextMock<SeriesEntity>(new List<SeriesEntity>
-            {
-                new SeriesEntity { Id = 1, Name = "Series 1", Players = 100 },
-                new SeriesEntity { Id = 2, Name = "Series 2", Players = 200 }
-            });
-
-            _seriesRepository = new SeriesRepository(_dbContextMock.Context);
+            _fixture = fixture;
         }
 
         [Fact]
         public async Task ShouldReturnListOfSeries()
         {
-            var series = await _seriesRepository.GetAll();
+            var series = await _fixture.Repository.GetAll();
 
             Assert.NotNull(series);
             Assert.IsType<List<SeriesEntity>>(series);
@@ -35,7 +27,7 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnSeriesById()
         {
-            var series = await _seriesRepository.GetById(1);
+            var series = await _fixture.Repository.GetById(1);
 
             Assert.NotNull(series);
             Assert.IsType<SeriesEntity>(series);
@@ -46,7 +38,7 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnSeriesByName()
         {
-            var series = await _seriesRepository.GetByName("Series 1");
+            var series = await _fixture.Repository.GetByName("Series 1");
 
             Assert.NotNull(series);
             Assert.IsType<SeriesEntity>(series);

--- a/Speedruns.Backend.Tests/Repositories/UserRepositoryTests.cs
+++ b/Speedruns.Backend.Tests/Repositories/UserRepositoryTests.cs
@@ -1,29 +1,23 @@
 ﻿using Speedruns.Backend.Entities;
-using Speedruns.Backend.Repositories;
-using Speedruns.Backend.Tests.Database;
+using Speedruns.Backend.Tests._Fixtures.Repositories;
 
 namespace Speedruns.Backend.Tests.Repositories
 {
-    public class UserRepositoryTests
+    public class UserRepositoryTests : IClassFixture<UserRepositoryFixture>
     {
-        private DbContextMock<UserEntity> _dbContextMock;
-        private UserRepository _userRepository;
 
-        public UserRepositoryTests()
+        private readonly UserRepositoryFixture _fixture;
+
+        public UserRepositoryTests(UserRepositoryFixture fixture)
         {
-            _dbContextMock = new DbContextMock<UserEntity>(new List<UserEntity>
-            {
-                new UserEntity { Id = 1, UserName = "Test 1", Runs = new List<RunEntity>{ new RunEntity { Id = 1, UserId = 1, ConsoleId = 1, GameId = 1, Time = 123 } } },
-                new UserEntity { Id = 2, UserName = "Test 2" },
-            });
-
-            _userRepository = new UserRepository(_dbContextMock.Context);
+            _fixture = fixture;
         }
-
+        
         [Fact]
         public async Task ShouldReturnListOfUsers()
         {
-            var users = await _userRepository.GetAll();
+            _fixture.ResetRepository();
+            var users = await _fixture.Repository.GetAll();
 
             Assert.NotNull(users);
             Assert.IsType<List<UserEntity>>(users);
@@ -34,7 +28,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnUserById()
         {
-            var user = await _userRepository.GetById(1);
+            _fixture.ResetRepository();
+            var user = await _fixture.Repository.GetById(1);
 
             Assert.NotNull(user);
             Assert.IsType<UserEntity>(user);
@@ -45,7 +40,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnNullUserById()
         {
-            var user = await _userRepository.GetById(100);
+            _fixture.ResetRepository();
+            var user = await _fixture.Repository.GetById(100);
 
             Assert.Null(user);
         }
@@ -53,7 +49,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnUserByName()
         {
-            var user = await _userRepository.GetByName("Test 1");
+            _fixture.ResetRepository();
+            var user = await _fixture.Repository.GetByName("Test 1");
 
             Assert.NotNull(user);
             Assert.IsType<UserEntity>(user);
@@ -64,7 +61,8 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnNullUserByName()
         {
-            var user = await _userRepository.GetByName("Test 3");
+            _fixture.ResetRepository();
+            var user = await _fixture.Repository.GetByName("Test 3");
 
             Assert.Null(user);
         }
@@ -72,9 +70,10 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnCreatedUser()
         {
+            _fixture.ResetRepository();
             var user = new UserEntity { Id = 3, UserName = "Test 3" };
 
-            var createdUser = await _userRepository.CreateUser(user);
+            var createdUser = await _fixture.Repository.CreateUser(user);
 
             Assert.NotNull(createdUser);
             Assert.IsType<UserEntity>(createdUser);
@@ -85,9 +84,10 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnUpdatedUser()
         {
+            _fixture.ResetRepository();
             var user = new UserEntity { Id = 1, UserName = "Testing 1" };
 
-            var updatedUser = await _userRepository.UpdateUser(user.Id, user);
+            var updatedUser = await _fixture.Repository.UpdateUser(user.Id, user);
 
             Assert.NotNull(updatedUser);
             Assert.IsType<UserEntity>(updatedUser);
@@ -98,9 +98,10 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldReturnNullUpdatedUser()
         {
+            _fixture.ResetRepository();
             var user = new UserEntity { Id = 100, UserName = "Testing 100" };
 
-            var updatedUser = await _userRepository.UpdateUser(user.Id, user);
+            var updatedUser = await _fixture.Repository.UpdateUser(user.Id, user);
 
             Assert.Null(updatedUser);
         }
@@ -108,11 +109,12 @@ namespace Speedruns.Backend.Tests.Repositories
         [Fact]
         public async Task ShouldDeleteUser()
         {
-            var userToDelete = await _userRepository.GetById(1);
+            _fixture.ResetRepository();
+            var userToDelete = await _fixture.Repository.GetById(1);
 
-            await _userRepository.DeleteUser(userToDelete);
+            await _fixture.Repository.DeleteUser(userToDelete);
 
-            var deletedUser = await _userRepository.GetById(1);
+            var deletedUser = await _fixture.Repository.GetById(1);
 
             Assert.Null(deletedUser);
         }

--- a/Speedruns.Backend.Tests/_Fixtures/Repositories/CommentsRepositoryFixture.cs
+++ b/Speedruns.Backend.Tests/_Fixtures/Repositories/CommentsRepositoryFixture.cs
@@ -1,0 +1,37 @@
+﻿using Speedruns.Backend.Entities;
+using Speedruns.Backend.Repositories;
+using Speedruns.Backend.Tests.Database;
+
+namespace Speedruns.Backend.Tests._Fixtures.Repositories
+{
+    public class CommentsRepositoryFixture
+    {
+        private DbContextMock<CommentEntity> _dbContextMock;
+        private CommentsRepository _commentsRepository;
+
+        public CommentsRepositoryFixture()
+        {
+            _dbContextMock = new DbContextMock<CommentEntity>(new List<CommentEntity>
+            {
+                new CommentEntity { Id = 1, Date = DateTime.UtcNow, Text = "Comment 1", UserId = 1, RunId = 1 },
+                new CommentEntity { Id = 2, Date = DateTime.UtcNow, Text = "Comment 2", UserId = 1, RunId = 1 },
+            });
+
+            _commentsRepository = new CommentsRepository(_dbContextMock.Context);
+        }
+
+        internal CommentsRepository Repository => _commentsRepository;
+
+        public void ResetRepository()
+        {
+            _dbContextMock = new DbContextMock<CommentEntity>(new List<CommentEntity>
+            {
+                new CommentEntity { Id = 1, Date = DateTime.UtcNow, Text = "Comment 1", UserId = 1, RunId = 1 },
+                new CommentEntity { Id = 2, Date = DateTime.UtcNow, Text = "Comment 2", UserId = 1, RunId = 1 },
+            });
+
+            _commentsRepository = new CommentsRepository(_dbContextMock.Context);
+        }
+       
+    }
+}

--- a/Speedruns.Backend.Tests/_Fixtures/Repositories/ConsolesRepositoryFixture.cs
+++ b/Speedruns.Backend.Tests/_Fixtures/Repositories/ConsolesRepositoryFixture.cs
@@ -1,0 +1,24 @@
+﻿using Speedruns.Backend.Entities;
+using Speedruns.Backend.Repositories;
+using Speedruns.Backend.Tests.Database;
+
+namespace Speedruns.Backend.Tests._Fixtures.Repositories
+{
+    public class ConsolesRepositoryFixture
+    {
+        private DbContextMock<ConsoleEntity> _dbContextMock;
+        private ConsolesRepository _consoleRepository;
+
+        public ConsolesRepositoryFixture()
+        {
+            _dbContextMock = new DbContextMock<ConsoleEntity>(new List<ConsoleEntity>
+            {
+                new ConsoleEntity { Id = 1, Name = "Console 1" },
+                new ConsoleEntity { Id = 2, Name = "Console 2" },
+            });
+            _consoleRepository = new ConsolesRepository(_dbContextMock.Context);
+        }
+
+        internal ConsolesRepository Repository => _consoleRepository;
+    }
+}

--- a/Speedruns.Backend.Tests/_Fixtures/Repositories/GamesRepositoryFixture.cs
+++ b/Speedruns.Backend.Tests/_Fixtures/Repositories/GamesRepositoryFixture.cs
@@ -1,0 +1,25 @@
+﻿using Speedruns.Backend.Entities;
+using Speedruns.Backend.Repositories;
+using Speedruns.Backend.Tests.Database;
+
+namespace Speedruns.Backend.Tests._Fixtures.Repositories
+{
+    public class GamesRepositoryFixture
+    {
+        private DbContextMock<GameEntity> _dbContextMock;
+        private GamesRepository _gamesRepository;
+
+        public GamesRepositoryFixture()
+        {
+            _dbContextMock = new DbContextMock<GameEntity>(new List<GameEntity>
+            {
+                new GameEntity { Id = 1, Name = "Super Mario 64", ReleaseYear = 1996, Players = 100, RunsPublished = 1000 },
+                new GameEntity { Id = 2, Name = "Kingdom Hearts 2 Final Mix", ReleaseYear = 2007, Players = 50, RunsPublished = 1000 },
+            });
+
+            _gamesRepository = new GamesRepository(_dbContextMock.Context);
+        }
+
+        internal GamesRepository Repository => _gamesRepository;
+    }
+}

--- a/Speedruns.Backend.Tests/_Fixtures/Repositories/RunRepositoryFixture.cs
+++ b/Speedruns.Backend.Tests/_Fixtures/Repositories/RunRepositoryFixture.cs
@@ -1,0 +1,64 @@
+﻿using NSubstitute;
+using Speedruns.Backend.Entities;
+using Speedruns.Backend.Interfaces;
+using Speedruns.Backend.Repositories;
+using Speedruns.Backend.Tests.Database;
+
+namespace Speedruns.Backend.Tests._Fixtures.Repositories
+{
+    public class RunRepositoryFixture
+    {
+        private DbContextMock<RunEntity> _dbContextMock;
+        private RunRepository _runRepository;
+        private IGamesRepository _gamesRepository;
+
+        public RunRepositoryFixture()
+        {
+            _dbContextMock = new DbContextMock<RunEntity>(new List<RunEntity>
+            {
+                new RunEntity { Id = 1, UserId = 1, GameId = 1, Time = 123, Console = new ConsoleEntity { Name = "PlayStation 1" } },
+                new RunEntity { Id = 2, UserId = 1, GameId = 2, Time = 123 },
+            });
+
+            _gamesRepository = Substitute.For<IGamesRepository>();
+            _gamesRepository
+                .GetById(1)
+                .Returns(new GameEntity
+                {
+                    Id = 1,
+                    Name = "Super Mario 64",
+                    ReleaseYear = 1996,
+                    Players = 100,
+                    RunsPublished = 1000
+                });
+
+            _runRepository = new RunRepository(_dbContextMock.Context, _gamesRepository);
+        }
+
+        internal RunRepository RunRepository => _runRepository;
+        internal IGamesRepository GameRepository => _gamesRepository;
+
+        public void ResetRepository()
+        {
+            _dbContextMock = new DbContextMock<RunEntity>(new List<RunEntity>
+            {
+                new RunEntity { Id = 1, UserId = 1, GameId = 1, Time = 123, Console = new ConsoleEntity { Name = "PlayStation 1" } },
+                new RunEntity { Id = 2, UserId = 1, GameId = 2, Time = 123 },
+            });
+
+            _gamesRepository = Substitute.For<IGamesRepository>();
+            _gamesRepository
+                .GetById(1)
+                .Returns(new GameEntity
+                {
+                    Id = 1,
+                    Name = "Super Mario 64",
+                    ReleaseYear = 1996,
+                    Players = 100,
+                    RunsPublished = 1000
+                });
+
+            _runRepository = new RunRepository(_dbContextMock.Context, _gamesRepository);
+        }
+    }
+}

--- a/Speedruns.Backend.Tests/_Fixtures/Repositories/SeriesRepositoryFixture.cs
+++ b/Speedruns.Backend.Tests/_Fixtures/Repositories/SeriesRepositoryFixture.cs
@@ -1,0 +1,25 @@
+﻿using Speedruns.Backend.Entities;
+using Speedruns.Backend.Repositories;
+using Speedruns.Backend.Tests.Database;
+
+namespace Speedruns.Backend.Tests._Fixtures.Repositories
+{
+    public class SeriesRepositoryFixture
+    {
+        private DbContextMock<SeriesEntity> _dbContextMock;
+        private SeriesRepository _seriesRepository;
+
+        public SeriesRepositoryFixture()
+        {
+            _dbContextMock = new DbContextMock<SeriesEntity>(new List<SeriesEntity>
+            {
+                new SeriesEntity { Id = 1, Name = "Series 1", Players = 100 },
+                new SeriesEntity { Id = 2, Name = "Series 2", Players = 200 }
+            });
+
+            _seriesRepository = new SeriesRepository(_dbContextMock.Context);
+        }
+
+        internal SeriesRepository Repository => _seriesRepository;
+    }
+}

--- a/Speedruns.Backend.Tests/_Fixtures/Repositories/UserRepositoryFixture.cs
+++ b/Speedruns.Backend.Tests/_Fixtures/Repositories/UserRepositoryFixture.cs
@@ -1,0 +1,36 @@
+﻿using Speedruns.Backend.Entities;
+using Speedruns.Backend.Repositories;
+using Speedruns.Backend.Tests.Database;
+
+namespace Speedruns.Backend.Tests._Fixtures.Repositories
+{
+    public class UserRepositoryFixture
+    {
+        private DbContextMock<UserEntity> _dbContextMock;
+        private UserRepository _userRepository;
+
+        public UserRepositoryFixture()
+        {
+            _dbContextMock = new DbContextMock<UserEntity>(new List<UserEntity>
+            {
+                new UserEntity { Id = 1, UserName = "Test 1", Runs = new List<RunEntity>{ new RunEntity { Id = 1, UserId = 1, ConsoleId = 1, GameId = 1, Time = 123 } } },
+                new UserEntity { Id = 2, UserName = "Test 2" },
+            });
+
+            _userRepository = new UserRepository(_dbContextMock.Context);
+        }
+
+        internal UserRepository Repository => _userRepository;
+
+        public void ResetRepository()
+        {
+            _dbContextMock = new DbContextMock<UserEntity>(new List<UserEntity>
+            {
+                new UserEntity { Id = 1, UserName = "Test 1", Runs = new List<RunEntity>{ new RunEntity { Id = 1, UserId = 1, ConsoleId = 1, GameId = 1, Time = 123 } } },
+                new UserEntity { Id = 2, UserName = "Test 2" },
+            });
+
+            _userRepository = new UserRepository(_dbContextMock.Context);
+        }
+    }
+}


### PR DESCRIPTION
Each repository test class now uses a fixture to share the same object and resetting the data if needed